### PR TITLE
Update to support Mobx 4

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -18,12 +18,16 @@
     "basscss-colors": "2.2.0",
     "classnames": "2.2.5",
     "font-awesome": "4.7.0",
-    "mobx": "^3.3.1",
-    "mobx-react": "^4.3.3",
-    "mobx-react-devtools": "^4.2.15",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "mobx": "4.2.0",
+    "mobx-react": "^5.0.0",
+    "mobx-react-devtools": "^5.0.1"
+  },
+  "peerDependencies": {
+    "react": "15.4.2",
+    "react-dom": "15.4.2"
   },
   "devDependencies": {
     "babel-loader": "6.2.10",

--- a/demo/package.json
+++ b/demo/package.json
@@ -18,16 +18,12 @@
     "basscss-colors": "2.2.0",
     "classnames": "2.2.5",
     "font-awesome": "4.7.0",
-    "prop-types": "^15.6.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "mobx": "4.2.0",
     "mobx-react": "^5.0.0",
-    "mobx-react-devtools": "^5.0.1"
-  },
-  "peerDependencies": {
-    "react": "15.4.2",
-    "react-dom": "15.4.2"
+    "mobx-react-devtools": "^5.0.1",
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel-loader": "6.2.10",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2080,8 +2080,13 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoist-non-react-statics@^2.3.1:
+<<<<<<< Updated upstream
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+=======
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+>>>>>>> Stashed changes
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2652,6 +2657,7 @@ minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+<<<<<<< Updated upstream
 mobx-react-devtools@^4.2.15:
   version "4.2.15"
   resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-4.2.15.tgz#881c038fb83db4dffd1e72bbaf5374d26b2fdebb"
@@ -2665,6 +2671,21 @@ mobx-react@^4.3.3:
 mobx@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.3.1.tgz#c38fc1a287a0dda3f5d4b85efe1137fedd9dcdf0"
+=======
+mobx-react-devtools@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-5.0.1.tgz#9473c85929b2fc0c95086430419028cebd96fb3b"
+
+mobx-react@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.0.0.tgz#8d5a33be376fa22b184a6f555d40a6a3a8459a16"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
+mobx@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.2.0.tgz#ee0b0a4f3da2f4776225046ab208ac329a4841d4"
+>>>>>>> Stashed changes
 
 ms@0.7.1:
   version "0.7.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "match-media-mock": "0.1.0"
   },
   "peerDependencies": {
-    "mobx": "^2.5.0 || ^3.0.0",
+    "mobx": "^4.0.0",
     "prop-types": "^15.6.0",
     "react": "^15.0.0 || ^16.0.0"
   },
@@ -84,7 +84,7 @@
     "husky": "^0.12.0",
     "jsdom": "^11.3.0",
     "json-loader": "0.5.4",
-    "mobx": "^3.3.1",
+    "mobx": "4.2.0",
     "mocha": "3.2.0",
     "npm-run-all": "4.0.1",
     "nyc": "10.1.2",

--- a/src/MatchMediaProvider.jsx
+++ b/src/MatchMediaProvider.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { toJS, extendObservable, action, runInAction } from 'mobx';
+import { toJS, set, action, runInAction } from 'mobx';
 import { matchMedia, setMatchMediaConfig } from './matchMedia';
 
 let breakpoints;
@@ -42,7 +42,7 @@ export default class MatchMediaProvider extends Component {
 
   updateBreakpoints = action('update breakpoints', (key, val) => {
     const match = matchMedia(val).matches;
-    extendObservable(this.props.breakpoints, { [key]: match });
+    set(this.props.breakpoints, { [key]: match });
   });
 
   render() {


### PR DESCRIPTION
I've updated the dependencies to use mobx 4. 

Since the upgrade from mobx 3 to 4 introduces a breaking change. I would suggest releasing this as v2.0.0 to avoid strange semver problems in dependent packages.